### PR TITLE
Update 3._Notices.md

### DIFF
--- a/3._Notices.md
+++ b/3._Notices.md
@@ -2,7 +2,7 @@
 
 ## Code of Conduct
 
-Contact for Code of Conduct issues or inquires: Kyle Smith at support@lex.clinic or Simon Brown at *[Simon please add contact here]*
+Contact for Code of Conduct issues or inquires: Kyle Smith at support@lex.clinic or Simon Brown at simon@cnslabs.io
 
 ## License Acceptance
 
@@ -53,4 +53,5 @@ This section includes any Exclusion Notices made against a Draft Deliverable or 
 	(ii) identification of the specific part(s) of the Specification whose implementation makes the excluded claim a Necessary Claim.
 
 -----------------------------------------------------------------------------------------
+
 


### PR DESCRIPTION
@orbmis Can you add your contact on Code of Conduct section.

Even though our earlier comment on Governance.md agrees with your Licensee removal, we're reconsidering if we should keep it to avoid friction once the Association is up and running at full throttle. 

If we don't do Licensees right now, then we really shouldn't do exemptions either because if we're not doing copyright then we shouldn't also do patent because patent is the more advanced IP.

One of our arguments of why its a good thing to not do licensees right now, is because we can focus on mission critical roles of publishing these standards and creating events around these standards. However, we do believe that licensing and exempting are also mission critical roles when we're mature enough to take them on. 

On the counter side, starting with Licensee explicit listing would remove any friction when the association is in full throttle and would avoid creating a scenario where people might be not in favor of the new changes.